### PR TITLE
[FIX] Add esbuild plugin to generate ts decorator metadata

### DIFF
--- a/packages/controllers/src/timeslots/TimeslotsController.ts
+++ b/packages/controllers/src/timeslots/TimeslotsController.ts
@@ -1,5 +1,6 @@
 import { Controller } from "@tsed/di";
-import { Get } from "@tsed/schema";
+import { PathParams } from "@tsed/platform-params";
+import { Get, Max } from "@tsed/schema";
 
 @Controller("/timeslots")
 export class TimeslotsController {
@@ -14,10 +15,10 @@ export class TimeslotsController {
   }
 
   @Get("/:id")
-  async getTimeslotById() {
+  async getTimeslotById(@PathParams("id") @Max(50) id: number) {
     return {
-      id: 1,
-      name: "Timeslot 1"
+      id: id,
+      name: `Timeslot ${id}`
     };
   }
 }

--- a/packages/controllers/tsconfig.json
+++ b/packages/controllers/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
+    "module": "ESNext",
     "noEmit": false,
     "allowJs": false,
     "esModuleInterop": true,

--- a/packages/controllers/tsconfig.node.json
+++ b/packages/controllers/tsconfig.node.json
@@ -3,11 +3,8 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",
-//    "composite": true,
-//    "noEmit": false,
-//    "declaration": true,
     "target": "ESNext",
-    "module": "nodeNext",
+    "module": "ESNext",
     "moduleResolution": "nodeNext",
     "types": [
       "node",

--- a/packages/lambda/esbuild.plugins.cjs
+++ b/packages/lambda/esbuild.plugins.cjs
@@ -1,0 +1,5 @@
+const eslintPluginTsc = require("esbuild-plugin-tsc");
+
+module.exports = [eslintPluginTsc({
+  tsconfigPath: `${__dirname}/tsconfig.node.json`,
+})];

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.136",
     "esbuild": "0.20.2",
+    "esbuild-plugin-tsc": "0.4.0",
     "serverless-esbuild": "1.52.1",
     "serverless-offline": "13.3.3",
     "tslib": "2.6.2",

--- a/packages/lambda/serverless.yml
+++ b/packages/lambda/serverless.yml
@@ -16,11 +16,16 @@ package:
 
 custom:
   esbuild:
+    platform: "node"
+    mainFields:
+      - main
     packager: yarn
     bundle: true
-    minify: true
+    minify: false
     sourcemap: false
     keepNames: true
+    plugins: ./esbuild.plugins.cjs
+
   offline:
     useChildProcesses: true
 
@@ -30,4 +35,10 @@ functions:
     events:
       - http:
           path: /timeslots
+          method: get
+  timeslotsById:
+    handler: src/timeslots/handler.getTimeslotById
+    events:
+      - http:
+          path: /timeslots/{id}
           method: get

--- a/packages/lambda/src/timeslots/handler.ts
+++ b/packages/lambda/src/timeslots/handler.ts
@@ -1,4 +1,6 @@
+import "@tsed/ajv"; // enable validation
+
 import { TimeslotsController } from "@project/controllers/timeslots/TimeslotsController";
 import { PlatformServerless } from "@tsed/platform-serverless";
-
 export const getTimeslots = PlatformServerless.callback(TimeslotsController, "getTimeslots");
+export const getTimeslotById = PlatformServerless.callback(TimeslotsController, "getTimeslotById");

--- a/packages/lambda/tsconfig.node.json
+++ b/packages/lambda/tsconfig.node.json
@@ -4,7 +4,7 @@
     "rootDir": "./src",
     "outDir": "./dist",
     "target": "ESNext",
-    "module": "nodeNext",
+    "module": "ESNext",
     "moduleResolution": "nodeNext",
     "types": [
       "node",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1668,6 +1668,7 @@ __metadata:
     dotenv-expand: "npm:^11.0.6"
     dotenv-flow: "npm:^4.1.0"
     esbuild: "npm:0.20.2"
+    esbuild-plugin-tsc: "npm:0.4.0"
     find-my-way: "npm:8.1.0"
     serverless: "npm:^3.38.0"
     serverless-esbuild: "npm:1.52.1"
@@ -6090,6 +6091,17 @@ __metadata:
     es6-iterator: "npm:^2.0.3"
     es6-symbol: "npm:^3.1.1"
   checksum: 10c0/460932be9542473dbbddd183e21c15a66cfec1b2c17dae2b514e190d6fb2896b7eb683783d4b36da036609d2e1c93d2815f21b374dfccaf02a8978694c2f7b67
+  languageName: node
+  linkType: hard
+
+"esbuild-plugin-tsc@npm:0.4.0":
+  version: 0.4.0
+  resolution: "esbuild-plugin-tsc@npm:0.4.0"
+  dependencies:
+    strip-comments: "npm:^2.0.1"
+  peerDependencies:
+    typescript: ^4.0.0 || ^5.0.0
+  checksum: 10c0/80d80327b87c27c6054bea2d1236c1295420f05d392d6e7c3069e57f4359666bd005b70fb6cb44c2e5d0c3c4875c5c0358908f6a83e587a6025966977356bfff
   languageName: node
   linkType: hard
 
@@ -11581,6 +11593,13 @@ __metadata:
   version: 3.0.0
   resolution: "strip-bom@npm:3.0.0"
   checksum: 10c0/51201f50e021ef16672593d7434ca239441b7b760e905d9f33df6e4f3954ff54ec0e0a06f100d028af0982d6f25c35cd5cda2ce34eaebccd0250b8befb90d8f1
+  languageName: node
+  linkType: hard
+
+"strip-comments@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "strip-comments@npm:2.0.1"
+  checksum: 10c0/984321b1ec47a531bdcfddd87f217590934e2d2f142198a080ec88588280239a5b58a81ca780730679b6195e52afef83673c6d6466c07c2277f71f44d7d9553d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Updated tsconfig to avoid embedded **cjs** and **esm** code of tsed (added `"module": "EsNext"` option on tsconfig)
- Added `esbuild-plugin-tsc` + `./esbuild.plugins.cjs` to generate typescript metadata correctly. Metadata is required by decorators and typescript framework to now if a props/params is String/Number or something else. Without these metadata, the framework will considers props/params as an **Object** type.
- Added `import "@tsed/ajv"` in handler.ts to enable ValidationPipe and AJV schema validation.

> Note: The project works as expected on MacOs M1 (all arch)
> Have you node.js 20 installed ? have you run `yarn install` ?

